### PR TITLE
Update slither setting in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,8 @@ jobs:
       - run:
           name: slither-analysis
           command: |
-              set +e
-              python -m slither . --solc-disable-warnings --json slither-analysis.json
-              python -m slither . --solc-disable-warnings --print human-summary,contract-summary
+              python -m slither . --filter-paths "node_modules|contracts/old|contracts/mock|contracts/interface" --solc-disable-warnings --json slither-analysis.json
+              python -m slither . --filter-paths "node_modules|contracts/old|contracts/mock|contracts/interface" --solc-disable-warnings --print human-summary,contract-summary
               exit 0
       - store_artifacts:
           path: slither-analysis.json


### PR DESCRIPTION
## Changes
- Due to the new changes in our `Slither` processor, high severity issues will exit the CI flow with non-zero status causing the run to fail. This new config is done to properly filter out what needs to be analyzed with the new `Slither` setting and avoiding false negatives (namely excluding non core codes like those in `node_modules` which don't need to be addressed). Note that non-high severity issues will not exit the CI flow, and thus we might need to change the severity of some detectors if needed, and vice versa (ie. if a high severity issue is deemed as shouldn't break the CI run, we can drop the severity down to medium)